### PR TITLE
Fix/accent for user

### DIFF
--- a/api/controllers/UserController.php
+++ b/api/controllers/UserController.php
@@ -42,11 +42,23 @@ class UserController {
             $firstName = mb_convert_case($data['first_name'],MB_CASE_TITLE, 'UTF-8');
             $lastName  = mb_convert_case($data['last_name'],MB_CASE_TITLE, 'UTF-8' );
 
-            $firstNameStreamline = strtolower(preg_replace('/\s+/', '', $data['first_name']));
-            $lastNameStreamline = strtolower(preg_replace('/\s+/', '', $data['last_name']));
+            $firstNameStreamline = strtolower(
+                preg_replace(
+                    '/[^a-z0-9]/',
+                    '',
+                    iconv('UTF-8', 'ASCII//TRANSLIT', preg_replace('/\s+/', '', $data['first_name']))
+                )
+            );
+
+            $lastNameStreamline = strtolower(
+                preg_replace(
+                    '/[^a-z0-9]/',
+                    '',
+                    iconv('UTF-8', 'ASCII//TRANSLIT', preg_replace('/\s+/', '', $data['last_name']))
+                )
+            );
 
             $username = $firstNameStreamline . "_" . $lastNameStreamline;
-
 
         $userEntity = new UserEntity(
             null,
@@ -72,7 +84,6 @@ class UserController {
             echo json_encode(["error" => $e->getMessage()]);
         }
     }
-
 
       public function updateUser($id_user) {
         $existing = $this->userModel->find($id_user);

--- a/api/controllers/UserController.php
+++ b/api/controllers/UserController.php
@@ -39,13 +39,20 @@ class UserController {
             return;
         }
 
-        $username = strtolower($data['first_name'] . "_" . $data['last_name']);
+            $firstName = mb_convert_case($data['first_name'],MB_CASE_TITLE, 'UTF-8');
+            $lastName  = mb_convert_case($data['last_name'],MB_CASE_TITLE, 'UTF-8' );
+
+            $firstNameStreamline = strtolower(preg_replace('/\s+/', '', $data['first_name']));
+            $lastNameStreamline = strtolower(preg_replace('/\s+/', '', $data['last_name']));
+
+            $username = $firstNameStreamline . "_" . $lastNameStreamline;
+
 
         $userEntity = new UserEntity(
             null,
             $username,
-            $data['first_name'],
-            $data['last_name'],
+            $firstName,
+            $lastName,
             password_hash($data['password'], PASSWORD_BCRYPT),
             null
         );


### PR DESCRIPTION
added rules to save first names and last names respecting capitalized letters
added rules to format username as a combination of firstnames + lastnames: no capital letter, no accent, no special character, except one underscore to separate first from last.